### PR TITLE
Not logigng build parameters

### DIFF
--- a/src/main/java/com/hp/mercury/ci/jenkins/plugins/OOBuildStep.java
+++ b/src/main/java/com/hp/mercury/ci/jenkins/plugins/OOBuildStep.java
@@ -624,7 +624,6 @@ public class OOBuildStep extends Builder {
             if (key.startsWith("f_")) {
                 selectedFlowS = basepath + "/" + buildVariables.get(key);
             }
-            listener.getLogger().println("key:"+key+":"+buildVariables.get(key));
         }
 
         Assert.isTrue(selectedOOServer != null, "HP Operations Orchestration Server must be selected");


### PR DESCRIPTION
The HP OO plugin was logging all the build parameters, leaking password type parameters to the Jenkins log.
